### PR TITLE
fix: resolve overlay freeze, persist window position, throttle rendering

### DIFF
--- a/src/main/overlay-window.ts
+++ b/src/main/overlay-window.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, screen } from 'electron'
 import path from 'path'
+import { loadSettings, saveSettings } from './settings'
 
 let overlayWin: BrowserWindow | null = null
 
@@ -10,12 +11,16 @@ export function showOverlay(): BrowserWindow {
   }
 
   const { width, height } = screen.getPrimaryDisplay().workAreaSize
+  const settings = loadSettings()
+
+  const x = settings.overlayX ?? Math.round(width / 2 - 260)
+  const y = settings.overlayY ?? Math.round(height - 220)
 
   overlayWin = new BrowserWindow({
     width: 520,
     height: 140,
-    x: Math.round(width / 2 - 260),
-    y: Math.round(height - 220),
+    x,
+    y,
     frame: false,
     transparent: true,
     alwaysOnTop: true,
@@ -32,6 +37,13 @@ export function showOverlay(): BrowserWindow {
     },
   })
 
+  overlayWin.on('moved', () => {
+    if (!overlayWin) return
+    const [posX, posY] = overlayWin.getPosition()
+    const s = loadSettings()
+    saveSettings({ ...s, overlayX: posX, overlayY: posY })
+  })
+
   overlayWin.loadFile(path.join(__dirname, '../../src/overlay/index.html'))
   overlayWin.setIgnoreMouseEvents(false)
   return overlayWin
@@ -44,7 +56,11 @@ export function hideOverlay() {
 }
 
 export function setOverlayHeight(height: number) {
-  overlayWin?.setSize(520, height)
+  if (!overlayWin) return
+  const { height: screenHeight } = screen.getPrimaryDisplay().workAreaSize
+  const [x, currentY] = overlayWin.getPosition()
+  const newY = Math.min(currentY, screenHeight - height)
+  overlayWin.setBounds({ x, y: Math.max(0, newY), width: 520, height })
 }
 
 export function sendToOverlay(channel: string, ...args: any[]) {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -8,6 +8,8 @@ const settingsPath = path.join(configDir, 'settings.json')
 export interface Settings {
   hotkey: string
   activeModel: string
+  overlayX?: number
+  overlayY?: number
 }
 
 const DEFAULTS: Settings = {

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -154,6 +154,9 @@ function setRecordingVisual(paused) {
   }
 }
 
+// Pending rAF handle for batched markdown re-renders
+let _renderFrame = null
+
 // IPC from main process
 window.electronAPI.onState((state, data) => {
   if (state === 'recording') {
@@ -169,13 +172,28 @@ window.electronAPI.onState((state, data) => {
     showState('processing-state')
   } else if (state === 'streaming') {
     window._rawOutput = ''
+    if (_renderFrame) { cancelAnimationFrame(_renderFrame); _renderFrame = null }
     document.getElementById('output-text').innerHTML = ''
     showState('streaming-state')
   } else if (state === 'token') {
     window._rawOutput = (window._rawOutput || '') + data
-    // Re-render full markdown on each token so formatting is always correct
-    document.getElementById('output-text').innerHTML = marked.parse(window._rawOutput)
+    // Batch re-renders to one per animation frame — avoids O(n²) work on long output
+    if (!_renderFrame) {
+      _renderFrame = requestAnimationFrame(() => {
+        const el = document.getElementById('output-text')
+        el.innerHTML = marked.parse(window._rawOutput)
+        el.scrollTop = el.scrollHeight
+        _renderFrame = null
+      })
+    }
   } else if (state === 'done') {
+    // Flush any pending render immediately so final output is complete
+    if (_renderFrame) {
+      cancelAnimationFrame(_renderFrame)
+      _renderFrame = null
+      const el = document.getElementById('output-text')
+      el.innerHTML = marked.parse(window._rawOutput)
+    }
     document.getElementById('done-status').textContent = data || ''
   }
 })


### PR DESCRIPTION
## Summary

- **Window freeze fix**: `setOverlayHeight` now adjusts the `y` position upward when expanding would push the window past the screen boundary — previously the window overflowed ~80px below the work area, causing macOS to restrict dragging
- **Persistent position**: overlay `x`/`y` saved to `settings.json` on `moved` event and restored on next launch, so the window opens where the user left it
- **Rendering throttle**: token updates are batched via `requestAnimationFrame` (one DOM re-render per frame max) rather than calling `marked.parse` on every token — eliminates the O(n²) rendering freeze on long transcripts; pending render is flushed immediately on `done` so the final output is always complete

## Test plan

- [ ] Record a long session — window should remain draggable throughout streaming
- [ ] Drag overlay to a non-default position, quit and relaunch — window should open at the saved position
- [ ] Verify streaming output renders correctly and scrolls to latest content
- [ ] Verify `done` status (Typed ✓ / Copied ✓) appears after streaming completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)