### PR TITLE
feat(overlay): wave-reveal streaming animation + shimmer finalization

### DIFF
--- a/src/overlay/index.html
+++ b/src/overlay/index.html
@@ -27,7 +27,7 @@
     </div>
 
     <div id="processing-state" class="state">
-      <div id="status-text" class="status-text">Transcribing…</div>
+      <div id="status-text" class="status-text">Transcribing… <span class="waiting-cursor"></span></div>
     </div>
 
     <div id="streaming-state" class="state">

--- a/src/overlay/index.html
+++ b/src/overlay/index.html
@@ -27,7 +27,7 @@
     </div>
 
     <div id="processing-state" class="state">
-      <div id="status-text" class="status-text">Transcribing… <span class="waiting-cursor"></span></div>
+      <div id="status-text" class="status-text"><span id="status-label">Transcribing…</span> <span class="waiting-cursor"></span></div>
     </div>
 
     <div id="streaming-state" class="state">

--- a/src/overlay/overlay.css
+++ b/src/overlay/overlay.css
@@ -233,3 +233,60 @@ kbd {
   padding-top: 6px;
   font-family: 'Menlo', 'Monaco', monospace;
 }
+
+/* ── Wave reveal (streaming token animation) ── */
+@keyframes wave-char-reveal {
+  0%   { max-width: 0;   opacity: 0;   filter: blur(8px); }
+  40%  { max-width: 1em; opacity: 0.5; filter: blur(4px); }
+  100% { max-width: 1em; opacity: 1;   filter: blur(0px); }
+}
+
+.wave-char {
+  display: inline-block;
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  white-space: pre;
+  vertical-align: bottom;
+  animation: wave-char-reveal 0.3s cubic-bezier(0.215, 0.61, 0.355, 1.0) forwards;
+}
+
+.wave-reveal-container {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+}
+
+/* ── Blinking cursor (waiting/processing state) ── */
+@keyframes cursor-blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.2; }
+}
+
+.waiting-cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background-color: currentColor;
+  border-radius: 1px;
+  animation: cursor-blink 1.8s ease-in-out infinite;
+  vertical-align: middle;
+}
+
+/* ── Shimmer effect (finalizing state) ── */
+@keyframes text-shimmer {
+  0%, 100% { -webkit-text-fill-color: var(--shimmer-bright); }
+  50%       { -webkit-text-fill-color: var(--shimmer-dim); }
+}
+
+#output-text.shimmer {
+  --shimmer-bright: rgba(255, 248, 235, 0.95);
+  --shimmer-dim: rgba(255, 248, 235, 0.25);
+  -webkit-text-fill-color: rgba(255, 248, 235, 0.95);
+  animation: text-shimmer 1.2s ease-in-out infinite;
+}
+
+#output-text.finalized {
+  animation: none;
+  -webkit-text-fill-color: unset;
+}

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -131,6 +131,8 @@ window.electronAPI.onRecordingCommand((command) => {
 
 // Pause state
 let isPaused = false
+let _shimmerTimer = null
+let _outputEl = null
 
 function setRecordingVisual(paused) {
   const dot = document.querySelector('.rec-dot')
@@ -169,7 +171,7 @@ function renderWaveToken(token) {
 }
 
 function appendToken(token) {
-  const el = document.getElementById('output-text')
+  const el = _outputEl
   if (token.trim().split(/\s+/).filter(Boolean).length > 5) {
     const span = document.createElement('span')
     span.textContent = token
@@ -194,8 +196,10 @@ window.electronAPI.onState((state, data) => {
     document.getElementById('status-label').textContent = data || 'Transcribing…'
     showState('processing-state')
   } else if (state === 'streaming') {
+    if (_shimmerTimer) { clearTimeout(_shimmerTimer); _shimmerTimer = null }
     window._rawOutput = ''
     const el = document.getElementById('output-text')
+    _outputEl = el
     el.innerHTML = ''
     el.classList.remove('shimmer', 'finalized')
     showState('streaming-state')
@@ -205,7 +209,8 @@ window.electronAPI.onState((state, data) => {
   } else if (state === 'done') {
     const el = document.getElementById('output-text')
     el.classList.add('shimmer')
-    setTimeout(() => {
+    _shimmerTimer = setTimeout(() => {
+      _shimmerTimer = null
       el.classList.remove('shimmer')
       el.classList.add('finalized')
       el.innerHTML = marked.parse(window._rawOutput || '')
@@ -213,6 +218,7 @@ window.electronAPI.onState((state, data) => {
       document.getElementById('done-status').textContent = data || ''
     }, 600)
   } else if (state === 'error') {
+    if (_shimmerTimer) { clearTimeout(_shimmerTimer); _shimmerTimer = null }
     stopWaveform()
     document.getElementById('error-text').textContent = data || 'An error occurred'
     showState('error-state')

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -191,7 +191,7 @@ window.electronAPI.onState((state, data) => {
     setRecordingVisual(true)
   } else if (state === 'processing') {
     stopWaveform()
-    document.getElementById('status-text').textContent = data || 'Transcribing...'
+    document.getElementById('status-label').textContent = data || 'Transcribing…'
     showState('processing-state')
   } else if (state === 'streaming') {
     window._rawOutput = ''

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -154,8 +154,31 @@ function setRecordingVisual(paused) {
   }
 }
 
-// Pending rAF handle for batched markdown re-renders
-let _renderFrame = null
+// ── Wave-reveal helpers ─────────────────────────────────────────────────────
+function renderWaveToken(token) {
+  const container = document.createElement('span')
+  container.className = 'wave-reveal-container'
+  ;[...token].forEach((char, i) => {
+    const span = document.createElement('span')
+    span.className = 'wave-char'
+    span.style.animationDelay = `${i * 30}ms`
+    span.textContent = char === ' ' ? '\u00A0' : char
+    container.appendChild(span)
+  })
+  return container
+}
+
+function appendToken(token) {
+  const el = document.getElementById('output-text')
+  if (token.trim().split(/\s+/).filter(Boolean).length > 5) {
+    const span = document.createElement('span')
+    span.textContent = token
+    el.appendChild(span)
+  } else {
+    el.appendChild(renderWaveToken(token))
+  }
+  el.scrollTop = el.scrollHeight
+}
 
 // IPC from main process
 window.electronAPI.onState((state, data) => {
@@ -172,29 +195,23 @@ window.electronAPI.onState((state, data) => {
     showState('processing-state')
   } else if (state === 'streaming') {
     window._rawOutput = ''
-    if (_renderFrame) { cancelAnimationFrame(_renderFrame); _renderFrame = null }
-    document.getElementById('output-text').innerHTML = ''
+    const el = document.getElementById('output-text')
+    el.innerHTML = ''
+    el.classList.remove('shimmer', 'finalized')
     showState('streaming-state')
   } else if (state === 'token') {
     window._rawOutput = (window._rawOutput || '') + data
-    // Batch re-renders to one per animation frame — avoids O(n²) work on long output
-    if (!_renderFrame) {
-      _renderFrame = requestAnimationFrame(() => {
-        const el = document.getElementById('output-text')
-        el.innerHTML = marked.parse(window._rawOutput)
-        el.scrollTop = el.scrollHeight
-        _renderFrame = null
-      })
-    }
+    appendToken(data)
   } else if (state === 'done') {
-    // Flush any pending render immediately so final output is complete
-    if (_renderFrame) {
-      cancelAnimationFrame(_renderFrame)
-      _renderFrame = null
-      const el = document.getElementById('output-text')
-      el.innerHTML = marked.parse(window._rawOutput)
-    }
-    document.getElementById('done-status').textContent = data || ''
+    const el = document.getElementById('output-text')
+    el.classList.add('shimmer')
+    setTimeout(() => {
+      el.classList.remove('shimmer')
+      el.classList.add('finalized')
+      el.innerHTML = marked.parse(window._rawOutput || '')
+      el.scrollTop = 0
+      document.getElementById('done-status').textContent = data || ''
+    }, 600)
   } else if (state === 'error') {
     stopWaveform()
     document.getElementById('error-text').textContent = data || 'An error occurred'


### PR DESCRIPTION
## Summary
- Replace rAF-batched markdown re-render with per-character wave-reveal animation (blur→clear, staggered 30ms delays)
- Add shimmer transition (600ms) on LLM completion before replacing content with `marked.parse()` output
- Add blinking waiting cursor in processing state (STT in progress)
- Scroll to bottom during streaming, scroll to top on finalized
- Large chunk fast-path: tokens >5 words append instantly to prevent animation queue buildup
- Shimmer scoped to `#output-text` only — overlay shell stays visually stable
- Cancellable shimmer timer (`_shimmerTimer`) so new recordings or errors don't fire stale DOM updates

## Test plan
- [ ] Processing state shows "Transcribing… |" with blinking cursor after stopping recording
- [ ] Streaming tokens appear with blur→clear wave animation, scroll tracks bottom
- [ ] Long LLM responses (>5 words per chunk) appear instantly without animation queue
- [ ] On done: output pulses bright↔dim for ~600ms then snaps to rendered Markdown
- [ ] Scroll jumps to top after finalization
- [ ] Starting a new recording clears output with no lingering shimmer/finalized classes
- [ ] Starting a new recording mid-shimmer cancels the shimmer timer cleanly

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)