### PR TITLE
fix: whisper-cli flags, blurt_output tag extraction, streaming display

### DIFF
--- a/src/main/modes.ts
+++ b/src/main/modes.ts
@@ -6,6 +6,7 @@ export interface Mode {
   id: string
   name: string
   prompt: string
+  outputType?: string // e.g. "cleaned text", "formatted email" — injected into CRITICAL INSTRUCTION
   hotkey: string | null
   whisperModel?: string // whisper model id; defaults to 'base.en' if absent
   temperature?: number
@@ -20,9 +21,8 @@ const DEFAULT_MODES: Mode[] = [
   {
     id: 'message',
     name: 'Message',
+    outputType: 'cleaned text',
     prompt: `You are a specialized text reformatting assistant. Your ONLY job is to clean up and reformat the user's text input.
-
-CRITICAL INSTRUCTION: Your response must ONLY contain the cleaned text. Nothing else.
 
 WHAT YOU DO:
 - Fix grammar, spelling, and punctuation
@@ -65,9 +65,8 @@ Remember: You are a text editor, NOT a conversational assistant. Only reformat, 
   {
     id: 'quick-note',
     name: 'Quick Note',
+    outputType: 'structured notes',
     prompt: `You are a note-taking specialist. Your job is to extract key information and organize it into structured notes.
-
-CRITICAL INSTRUCTION: Your response must ONLY contain the structured notes. Nothing else.
 
 NOTE FORMATTING REQUIREMENTS:
 1. Structure text for effective note taking
@@ -95,9 +94,8 @@ Wrong: Adding interpretations or assumptions`,
   {
     id: 'email',
     name: 'Email',
+    outputType: 'formatted email',
     prompt: `You are an email formatting specialist. Your task is to transform user messages into professional email format.
-
-CRITICAL INSTRUCTION: Your response must ONLY contain the formatted email. Nothing else.
 
 EMAIL STRUCTURE REQUIREMENTS:
 1. Greeting: "Hey there," (if no name) or "Hey [Name]," (if name provided)
@@ -136,9 +134,8 @@ Wrong: Including signatures, names, or additional text after sign-off`,
   {
     id: 'meeting',
     name: 'Meeting',
+    outputType: 'meeting summary',
     prompt: `You are a meeting transcript summarizer. Your job is to create structured summaries from actual meeting transcripts.
-
-CRITICAL INSTRUCTION: Your response must ONLY contain the meeting summary. Nothing else.
 
 SUMMARY FORMAT REQUIREMENTS:
 1. Action items clearly marked with responsible person if applicable
@@ -156,9 +153,8 @@ SUMMARY FORMAT REQUIREMENTS:
   {
     id: 'agent',
     name: 'Agent',
+    outputType: 'agent-ready instruction',
     prompt: `You are a prompt engineer. Transform the user's stream-of-consciousness dictation into a clear, direct instruction for an AI coding agent.
-
-CRITICAL INSTRUCTION: Your response must ONLY contain the agent-ready instruction. Nothing else.
 
 WHAT YOU DO:
 - Start with a clear imperative: "Fix...", "Add...", "Refactor...", "Implement..."
@@ -190,9 +186,8 @@ Correct: Start directly with the imperative.`,
   {
     id: 'dev-note',
     name: 'Dev Note',
+    outputType: 'developer note',
     prompt: `You are a technical writing assistant. Transform the spoken dictation into a clean, structured developer note.
-
-CRITICAL INSTRUCTION: Your response must ONLY contain the developer note. Nothing else.
 
 WHAT YOU DO:
 - Write as a technical reference: clear, precise, and scannable

--- a/src/main/pipeline.ts
+++ b/src/main/pipeline.ts
@@ -7,7 +7,7 @@ import { showOverlay, hideOverlay, sendToOverlay, setOverlayHeight } from './ove
 import { loadModes } from './modes'
 import { getActiveModeId } from './tray'
 import { log } from './logger'
-import { stripPreamble } from './preamble'
+import { extractBlurtOutput } from './preamble'
 
 const recorder = new Recorder()
 let frontmostApp: string | null = null
@@ -66,17 +66,44 @@ async function stopRecording() {
     const initialPrompt = activeMode.vocabulary?.join(', ')
     const rawText = await transcribe(wavPath, activeMode.whisperModel, initialPrompt)
 
-    sendToOverlay('overlay-state', 'processing', 'Summarising...')
-    setOverlayHeight(300)
-    sendToOverlay('overlay-state', 'streaming')
+    sendToOverlay('overlay-state', 'processing', 'Thinking...')
 
+    const OPEN = '<blurt_output>'
+    const CLOSE = '</blurt_output>'
     let fullText = ''
+    let tagFound = false
+    let lastSent = 0
+
     for await (const token of summarize(rawText, activeMode)) {
       fullText += token
-      sendToOverlay('overlay-state', 'token', token)
+
+      if (!tagFound) {
+        const i = fullText.indexOf(OPEN)
+        if (i === -1) continue
+        tagFound = true
+        lastSent = i + OPEN.length
+        setOverlayHeight(300)
+        sendToOverlay('overlay-state', 'streaming')
+      }
+
+      const closeAt = fullText.indexOf(CLOSE, lastSent)
+      const safeEnd = closeAt !== -1
+        ? closeAt
+        : fullText.length - CLOSE.length
+
+      if (safeEnd > lastSent) {
+        sendToOverlay('overlay-state', 'token', fullText.slice(lastSent, safeEnd))
+        lastSent = safeEnd
+      }
     }
 
-    const cleanText = stripPreamble(fullText)
+    // If model never produced the tag, still switch to streaming so 'done' renders
+    if (!tagFound) {
+      setOverlayHeight(300)
+      sendToOverlay('overlay-state', 'streaming')
+    }
+
+    const cleanText = extractBlurtOutput(fullText)
     clipboard.writeText(cleanText)
     const canType = systemPreferences.isTrustedAccessibilityClient(false)
     if (frontmostApp && canType) {

--- a/src/main/preamble.test.ts
+++ b/src/main/preamble.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { stripPreamble } from './preamble'
+import { stripPreamble, stripThinkBlocks, stripLLMArtifacts, extractBlurtOutput, extractStreamingVisible } from './preamble'
 
 describe('stripPreamble', () => {
   it('strips "Here are your notes:" intro', () => {
@@ -69,5 +69,105 @@ describe('stripPreamble', () => {
   it('strips "Alright, here is your summary:" intro', () => {
     const input = 'Alright, here is your summary:\n\nKey takeaways below.'
     expect(stripPreamble(input)).toBe('Key takeaways below.')
+  })
+})
+
+describe('stripThinkBlocks', () => {
+  it('strips empty think block', () => {
+    expect(stripThinkBlocks('<think></think>\nHello world')).toBe('Hello world')
+  })
+
+  it('strips think block with content', () => {
+    expect(stripThinkBlocks('<think>reasoning here</think>\nHello world')).toBe('Hello world')
+  })
+
+  it('strips multiline think block', () => {
+    expect(stripThinkBlocks('<think>\nstep 1\nstep 2\n</think>\nResult')).toBe('Result')
+  })
+
+  it('passes through text with no think block', () => {
+    expect(stripThinkBlocks('Hello world')).toBe('Hello world')
+  })
+
+  it('handles partial think block (still open — incomplete stream)', () => {
+    expect(stripThinkBlocks('<think>still thinking')).toBe('')
+  })
+})
+
+describe('extractStreamingVisible', () => {
+  it('returns empty before blurt_output tag appears', () => {
+    expect(extractStreamingVisible('<think>reasoning</think>\n')).toBe('')
+  })
+
+  it('returns empty while blurt_output tag is still forming (no closing >)', () => {
+    expect(extractStreamingVisible('<blurt_output')).toBe('')
+  })
+
+  it('returns empty for bare < that could be start of opening tag', () => {
+    expect(extractStreamingVisible('<')).toBe('')
+  })
+
+  it('strips partial closing tag chars from streamed content', () => {
+    expect(extractStreamingVisible('<blurt_output>Hello</blurt_outp')).toBe('Hello')
+  })
+
+  it('strips single < that starts the closing tag sequence', () => {
+    expect(extractStreamingVisible('<blurt_output>Hello<')).toBe('Hello')
+  })
+
+  it('returns content progressively once inside open tag', () => {
+    expect(extractStreamingVisible('<blurt_output>Hello')).toBe('Hello')
+  })
+
+  it('returns trimmed content from complete tag', () => {
+    expect(extractStreamingVisible('<blurt_output>\nHello world\n</blurt_output>')).toBe('Hello world')
+  })
+
+  it('returns full content when no tags present (fallback)', () => {
+    expect(extractStreamingVisible('Hello world')).toBe('Hello world')
+  })
+
+  it('fallback strips think blocks', () => {
+    expect(extractStreamingVisible('<think>reasoning</think>\nHello world')).toBe('Hello world')
+  })
+})
+
+describe('extractBlurtOutput', () => {
+  it('extracts content from blurt_output tags', () => {
+    expect(extractBlurtOutput('<blurt_output>Hello world</blurt_output>')).toBe('Hello world')
+  })
+
+  it('ignores content outside the tags', () => {
+    expect(extractBlurtOutput('<think>reasoning</think>\n<blurt_output>Hello world</blurt_output>')).toBe('Hello world')
+  })
+
+  it('handles multiline content inside tags', () => {
+    expect(extractBlurtOutput('<blurt_output>Line one\nLine two</blurt_output>')).toBe('Line one\nLine two')
+  })
+
+  it('trims whitespace inside tags', () => {
+    expect(extractBlurtOutput('<blurt_output>\n  Hello world\n</blurt_output>')).toBe('Hello world')
+  })
+
+  it('falls back to full stripping pipeline when no tags present', () => {
+    expect(extractBlurtOutput('Hello world')).toBe('Hello world')
+  })
+
+  it('fallback strips think blocks and artifacts', () => {
+    expect(extractBlurtOutput('<think>reasoning</think>\nHello world\n[end of text]')).toBe('Hello world')
+  })
+})
+
+describe('stripLLMArtifacts', () => {
+  it('strips "[end of text]"', () => {
+    expect(stripLLMArtifacts('Hello world\n[end of text]')).toBe('Hello world')
+  })
+
+  it('strips case-insensitively', () => {
+    expect(stripLLMArtifacts('Hello world\n[END OF TEXT]')).toBe('Hello world')
+  })
+
+  it('passes through normal text', () => {
+    expect(stripLLMArtifacts('Hello world')).toBe('Hello world')
   })
 })

--- a/src/main/preamble.ts
+++ b/src/main/preamble.ts
@@ -1,3 +1,48 @@
+export function extractStreamingVisible(text: string): string {
+  // Complete tag block — return trimmed content
+  const complete = text.match(/<blurt_output>([\s\S]*?)<\/blurt_output>/)
+  if (complete) return complete[1].trim()
+
+  // Inside an open (not yet closed) tag — stream content progressively,
+  // but strip any trailing prefix of </blurt_output> to prevent closing tag chars leaking
+  const open = text.match(/<blurt_output>([\s\S]*)$/)
+  if (open) {
+    const closing = '</blurt_output>'
+    let content = open[1]
+    for (let i = closing.length - 1; i >= 1; i--) {
+      if (content.endsWith(closing.slice(0, i))) return content.slice(0, -i)
+    }
+    return content
+  }
+
+  // Partial opening tag still forming — suppress until we know it's complete
+  if (text.includes('<blurt_output')) return ''
+  const opening = '<blurt_output>'
+  for (let i = opening.length - 1; i >= 1; i--) {
+    if (text.endsWith(opening.slice(0, i))) return ''
+  }
+
+  // No tags at all — fallback: strip think blocks and show whatever we have
+  return stripThinkBlocks(text)
+}
+
+export function extractBlurtOutput(text: string): string {
+  const match = text.match(/<blurt_output>([\s\S]*?)<\/blurt_output>/)
+  if (match) return match[1].trim()
+  // Fallback: no tags — run the stripping pipeline
+  return stripPreamble(stripLLMArtifacts(stripThinkBlocks(text)))
+}
+
+export function stripThinkBlocks(text: string): string {
+  const stripped = text.replace(/<think>[\s\S]*?<\/think>/g, '')
+  const partial = stripped.replace(/<think>[\s\S]*$/, '')
+  return partial.trimStart()
+}
+
+export function stripLLMArtifacts(text: string): string {
+  return text.replace(/\[end of text\]/gi, '').trim()
+}
+
 const PREAMBLE_STARTERS = [
   'here',
   'sure',

--- a/src/main/summarizer.ts
+++ b/src/main/summarizer.ts
@@ -105,6 +105,7 @@ function buildSystemPrompt(): string {
 function buildUserMessage(
   modePrompt: string,
   transcript: string,
+  outputType = 'formatted output',
   examples: Array<{ input: string; output: string }> = [],
   language = 'English',
 ): string {
@@ -120,6 +121,10 @@ function buildUserMessage(
     `INSTRUCTIONS:\n${modePrompt}`,
     '',
     `The user is speaking ${language}, reformatted message should also be in ${language}.`,
+    '',
+    `CRITICAL INSTRUCTION: Your response must ONLY contain the ${outputType}. Nothing else.`,
+    'Wrap your entire response in <blurt_output> tags like this:',
+    `<blurt_output>your ${outputType} here</blurt_output>`,
   ]
 
   if (examples.length > 0) {
@@ -127,7 +132,7 @@ function buildUserMessage(
     parts.push('EXAMPLES OF CORRECT BEHAVIOR:')
     for (const ex of examples) {
       parts.push(`User: ${ex.input}`)
-      parts.push(`Assistant: ${ex.output}`)
+      parts.push(`Assistant: <blurt_output>${ex.output}</blurt_output>`)
     }
   }
 
@@ -147,7 +152,7 @@ function buildUserMessage(
 
 function formatPrompt(template: ChatTemplate, mode: Mode, transcript: string): string {
   const system = buildSystemPrompt()
-  const user = buildUserMessage(mode.prompt, transcript, mode.examples ?? [])
+  const user = buildUserMessage(mode.prompt, transcript, mode.outputType, mode.examples ?? [])
 
   switch (template) {
     case 'chatml':

--- a/src/main/transcriber.test.ts
+++ b/src/main/transcriber.test.ts
@@ -31,12 +31,17 @@ describe('Whisper model helpers', () => {
 })
 
 describe('Transcriber', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     mockExecFile.mockReset()
-    // Both ffmpeg and whisper-cli succeed
     mockExecFile.mockImplementation((_bin: string, _args: string[], _opts: object, cb: Function) => {
       cb(null, '', '')
     })
+    const fs = await import('fs')
+    vi.mocked(fs.existsSync).mockReset()
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    vi.mocked(fs.readFileSync).mockReset()
+    vi.mocked(fs.readFileSync).mockReturnValue('Hello world  \n')
+    vi.mocked(fs.unlinkSync).mockReset()
   })
 
   it('preprocesses audio then calls whisper-cli with preprocessed path', async () => {
@@ -145,6 +150,35 @@ describe('Transcriber', () => {
     expect(whisperArgs).not.toContain('--prompt')
   })
 
+  it('uses --no-speech-thold flag (not --no-speech-thr)', async () => {
+    vi.resetModules()
+    const { transcribe } = await import('./transcriber')
+    await transcribe('/tmp/test.wav')
+
+    const whisperArgs: string[] = mockExecFile.mock.calls[1][1]
+    expect(whisperArgs).toContain('--no-speech-thold')
+    expect(whisperArgs).not.toContain('--no-speech-thr')
+  })
+
+  it('uses --logprob-thold flag (not --logprob-thr)', async () => {
+    vi.resetModules()
+    const { transcribe } = await import('./transcriber')
+    await transcribe('/tmp/test.wav')
+
+    const whisperArgs: string[] = mockExecFile.mock.calls[1][1]
+    expect(whisperArgs).toContain('--logprob-thold')
+    expect(whisperArgs).not.toContain('--logprob-thr')
+  })
+
+  it('does not pass --compression-ratio-thr (unsupported flag)', async () => {
+    vi.resetModules()
+    const { transcribe } = await import('./transcriber')
+    await transcribe('/tmp/test.wav')
+
+    const whisperArgs: string[] = mockExecFile.mock.calls[1][1]
+    expect(whisperArgs).not.toContain('--compression-ratio-thr')
+  })
+
   it('does not pass --prompt to whisper-cli when initialPrompt is empty string', async () => {
     vi.resetModules()
     const { transcribe } = await import('./transcriber')
@@ -152,6 +186,23 @@ describe('Transcriber', () => {
 
     const whisperArgs: string[] = mockExecFile.mock.calls[1][1]
     expect(whisperArgs).not.toContain('--prompt')
+  })
+
+  it('returns empty string when whisper exits successfully but produces no output file', async () => {
+    const fs = await import('fs')
+    vi.mocked(fs.existsSync).mockImplementation((p: unknown) =>
+      typeof p === 'string' && !p.endsWith('.txt')
+    )
+    vi.mocked(fs.unlinkSync).mockClear()
+
+    vi.resetModules()
+    const { transcribe } = await import('./transcriber')
+    const result = await transcribe('/tmp/test.wav')
+
+    expect(result).toBe('')
+    const unlinkedPaths = vi.mocked(fs.unlinkSync).mock.calls.map((c: unknown[]) => c[0])
+    expect(unlinkedPaths).toContain('/tmp/test-preprocessed.wav')
+    expect(unlinkedPaths).toContain('/tmp/test.wav')
   })
 })
 

--- a/src/main/transcriber.ts
+++ b/src/main/transcriber.ts
@@ -166,9 +166,8 @@ export async function transcribe(wavPath: string, whisperModelId?: string, initi
       '--output-txt',
       '--no-timestamps',
       '-np',
-      '--no-speech-thr', '0.6',
-      '--logprob-thr', '-1.0',
-      '--compression-ratio-thr', '2.4',
+      '--no-speech-thold', '0.6',
+      '--logprob-thold', '-1.0',
       '--temperature', '0',
       '--temperature-inc', '0.2',
       '--beam-size', '3',
@@ -179,7 +178,8 @@ export async function transcribe(wavPath: string, whisperModelId?: string, initi
     }
 
     log.info(`transcribe: ${bin} -m ${model} -f ${preprocessedPath}`)
-    execFile(bin, args, { timeout: 60000 }, (err) => {
+    execFile(bin, args, { timeout: 60000 }, (err, _stdout, stderr) => {
+      if (stderr) log.warn(`whisper-cli stderr: ${stderr.trim()}`)
       if (err) {
         log.error('whisper-cli failed', err)
         try { unlinkSync(preprocessedPath) } catch {}
@@ -187,6 +187,11 @@ export async function transcribe(wavPath: string, whisperModelId?: string, initi
         return reject(err)
       }
       const txtPath = preprocessedPath + '.txt'
+      if (!existsSync(txtPath)) {
+        try { unlinkSync(preprocessedPath) } catch {}
+        try { unlinkSync(wavPath) } catch {}
+        return resolve('')
+      }
       try {
         const raw = readFileSync(txtPath, 'utf-8')
         unlinkSync(txtPath)


### PR DESCRIPTION
## Summary

- **Whisper-cli ENOENT fix**: Wrong flag names (`--no-speech-thr` → `--no-speech-thold`, `--logprob-thr` → `--logprob-thold`) caused whisper-cli to silently exit 0 with no output file. Added `existsSync` guard and stderr logging.
- **Tag-based output extraction**: LLM prompt now wraps output in `<blurt_output>` tags. `extractBlurtOutput` reliably extracts content; fallback pipeline strips `<think>` blocks, `[end of text]`, and preamble.
- **Buffered lookahead streaming**: Replaced regex-based `extractStreamingVisible` (which suffered token-boundary corruption) with simple `indexOf` + hold-back buffer. Partial tags can never leak to the overlay.
- **Prompt cleanup**: Factored `CRITICAL INSTRUCTION` boilerplate out of individual mode prompts into the summarizer template. Added `outputType` field to all 6 default modes.

## Test plan

- [x] 80 tests passing (`yarn test`)
- [x] `yarn tsc --noEmit` clean
- [ ] Manual: record audio → verify overlay shows "Transcribing..." then "Thinking..." then clean streamed text (no `<blurt_output>` tags visible)
- [ ] Manual: verify typed/clipboard text is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)